### PR TITLE
Isaac players page

### DIFF
--- a/frontend/src/pages/Players/Players.css
+++ b/frontend/src/pages/Players/Players.css
@@ -433,3 +433,59 @@
   color: #444;
   margin-top: 0.1rem;
 }
+
+
+.sortable-th {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  transition: color 0.15s, background 0.15s;
+}
+
+.sortable-th:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.sortable-th.sort-active {
+  /* color is set inline via the team accent */
+}
+
+.th-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.sort-icon {
+  flex-shrink: 0;
+  opacity: 0.9;
+  position: relative;
+  top: 0px;
+}
+
+/* Title row with reset button */
+.players-career-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 0;
+}
+
+.sort-reset-btn {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  letter-spacing: 0.03em;
+}
+
+.sort-reset-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(255, 255, 255, 0.3);
+}

--- a/frontend/src/pages/Players/Players.tsx
+++ b/frontend/src/pages/Players/Players.tsx
@@ -7,11 +7,11 @@ interface Player {
   playerId: number;
   fullName: string;
   teamId: number;
-  team: string; // abbreviation e.g. "LAL"
+  team: string;
   teamName: string;
   fromYear: string;
   toYear: string;
-  rosterStatus: number; // 1 = active
+  rosterStatus: number;
 }
 
 interface CareerSeason {
@@ -35,6 +35,14 @@ interface CareerSeason {
 interface CareerStats {
   playerId: string;
   seasons: CareerSeason[];
+}
+
+type SortDirection = 'asc' | 'desc' | null;
+type SortKey = keyof CareerSeason;
+
+interface SortState {
+  key: SortKey | null;
+  direction: SortDirection;
 }
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
@@ -106,6 +114,47 @@ function useDebounce<T>(value: T, delay: number): T {
   return debounced;
 }
 
+// ─── Sort Icon ─────────────────────────────────────────────────────────────────
+
+function SortIcon({
+  direction,
+  active,
+  color,
+}: {
+  direction: SortDirection;
+  active: boolean;
+  color: string;
+}) {
+  const dimColor = 'rgba(255,255,255,0.18)';
+  const upActive = active && direction === 'asc';
+  const downActive = active && direction === 'desc';
+
+  return (
+    <span
+      className="sort-icon"
+      aria-hidden="true"
+      style={{ display: 'inline-flex', flexDirection: 'column', gap: '1px', marginLeft: '4px', verticalAlign: 'middle', lineHeight: 1 }}
+    >
+      {/* Up caret */}
+      <svg width="7" height="5" viewBox="0 0 7 5" fill="none">
+        <path
+          d="M3.5 0.5L6.5 4.5H0.5L3.5 0.5Z"
+          fill={upActive ? color : dimColor}
+          style={{ transition: 'fill 0.15s' }}
+        />
+      </svg>
+      {/* Down caret */}
+      <svg width="7" height="5" viewBox="0 0 7 5" fill="none">
+        <path
+          d="M3.5 4.5L0.5 0.5H6.5L3.5 4.5Z"
+          fill={downActive ? color : dimColor}
+          style={{ transition: 'fill 0.15s' }}
+        />
+      </svg>
+    </span>
+  );
+}
+
 // ─── Component ─────────────────────────────────────────────────────────────────
 
 export default function Players() {
@@ -122,11 +171,13 @@ export default function Players() {
   const [loadingCareer, setLoadingCareer] = useState(false);
   const [errorCareer, setErrorCareer] = useState<string | null>(null);
 
+  // ── Sort state ─────────────────────────────────────────────────────────────
+  const [sort, setSort] = useState<SortState>({ key: null, direction: null });
+
   const debouncedSearch = useDebounce(searchQuery, 300);
   const listRef = useRef<HTMLDivElement>(null);
 
   // ── 1. Fetch player list ───────────────────────────────────────────────────
-  // GET /api/players?search=&currentOnly=0|1
   useEffect(() => {
     const load = async () => {
       setLoadingPlayers(true);
@@ -151,13 +202,14 @@ export default function Players() {
   }, [debouncedSearch, activeOnly]);
 
   // ── 2. Fetch career stats when a player is selected ────────────────────────
-  // GET /api/players/:playerId/career
   useEffect(() => {
     if (!selectedPlayer) return;
     const load = async () => {
       setLoadingCareer(true);
       setErrorCareer(null);
       setCareerStats(null);
+      // Reset sort when switching players
+      setSort({ key: null, direction: null });
       try {
         const res = await fetch(
           `${API_BASE}/players/${selectedPlayer.playerId}/career`,
@@ -175,10 +227,43 @@ export default function Players() {
     load();
   }, [selectedPlayer]);
 
+  // ── Sort handler: cycles null → desc → asc → null (chronological) ──────────
+  const handleSort = useCallback((key: SortKey) => {
+    setSort((prev) => {
+      if (prev.key !== key) {
+        // New column: start with desc
+        return { key, direction: 'desc' };
+      }
+      if (prev.direction === 'desc') return { key, direction: 'asc' };
+      // Was asc → reset to chronological
+      return { key: null, direction: null };
+    });
+  }, []);
+
+  // ── Sort the seasons ───────────────────────────────────────────────────────
+  const sortedSeasons = (() => {
+    if (!careerStats?.seasons) return [];
+    const base = [...careerStats.seasons].sort((a, b) =>
+      b.season.localeCompare(a.season),
+    );
+    if (!sort.key || !sort.direction) return base;
+
+    return [...base].sort((a, b) => {
+      const aVal = a[sort.key!] ?? 0;
+      const bVal = b[sort.key!] ?? 0;
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return sort.direction === 'asc'
+          ? aVal.localeCompare(bVal)
+          : bVal.localeCompare(aVal);
+      }
+      const diff = (aVal as number) - (bVal as number);
+      return sort.direction === 'asc' ? diff : -diff;
+    });
+  })();
+
   // ── Derived values ─────────────────────────────────────────────────────────
   const colors = selectedPlayer ? getColors(selectedPlayer.team) : null;
 
-  // Most recent season for the stat highlights in the header
   const latestSeason = careerStats?.seasons?.length
     ? [...careerStats.seasons].sort((a, b) =>
         b.season.localeCompare(a.season),
@@ -189,6 +274,38 @@ export default function Players() {
     setSelectedPlayer(player);
   }, []);
 
+  // ── Column header helper ───────────────────────────────────────────────────
+  const Th = ({
+    label,
+    sortKey,
+    className,
+  }: {
+    label: string;
+    sortKey: SortKey;
+    className?: string;
+  }) => {
+    const isActive = sort.key === sortKey;
+    const accentColor = colors?.secondary ?? '#ffffff';
+
+    return (
+      <th
+        className={`sortable-th${isActive ? ' sort-active' : ''}${className ? ` ${className}` : ''}`}
+        onClick={() => handleSort(sortKey)}
+        style={isActive ? { color: accentColor } : undefined}
+        title={`Sort by ${label}`}
+      >
+        <span className="th-inner">
+          {label}
+          <SortIcon
+            direction={sort.direction}
+            active={isActive}
+            color={accentColor}
+          />
+        </span>
+      </th>
+    );
+  };
+
   // ── Render ─────────────────────────────────────────────────────────────────
   return (
     <div className="players-page">
@@ -196,7 +313,6 @@ export default function Players() {
       <aside className="players-sidebar">
         <h2 className="players-sidebar-title">Players</h2>
 
-        {/* Search */}
         <div className="players-search-wrap">
           <span className="players-search-icon">⌕</span>
           <input
@@ -208,7 +324,6 @@ export default function Players() {
           />
         </div>
 
-        {/* Active-only toggle */}
         <div className="players-toggle-row">
           <input
             id="active-toggle"
@@ -222,18 +337,15 @@ export default function Players() {
           </label>
         </div>
 
-        {/* Status */}
         {loadingPlayers && <p className="players-loading">Loading…</p>}
         {errorPlayers && <p className="players-error">{errorPlayers}</p>}
 
-        {/* Count */}
         {!loadingPlayers && players.length > 0 && (
           <p className="players-count-badge">
             {players.length} player{players.length !== 1 ? 's' : ''}
           </p>
         )}
 
-        {/* List */}
         <div className="players-list" ref={listRef}>
           {players.map((player) => {
             const c = getColors(player.team);
@@ -280,7 +392,6 @@ export default function Players() {
       {/* ── Main Panel ── */}
       <main className="players-main">
         <div className="players-panel">
-          {/* Empty state */}
           {!selectedPlayer && (
             <p className="players-placeholder">
               Select a player to view their career stats.
@@ -357,7 +468,6 @@ export default function Players() {
                     )}
                   </div>
 
-                  {/* Latest season highlight stats */}
                   {loadingCareer && (
                     <p className="players-loading">Loading stats…</p>
                   )}
@@ -411,34 +521,46 @@ export default function Players() {
               {/* ── Career Stats Table ── */}
               {careerStats && careerStats.seasons.length > 0 && (
                 <>
-                  <p className="players-career-title">Career Stats</p>
+                  <div className="players-career-title-row">
+                    <p className="players-career-title">Career Stats</p>
+                    {sort.key && (
+                      <button
+                        className="sort-reset-btn"
+                        onClick={() => setSort({ key: null, direction: null })}
+                        title="Reset to chronological order"
+                      >
+                        Reset order
+                      </button>
+                    )}
+                  </div>
                   <div className="players-career-table-wrap">
                     <table className="players-career-table">
                       <thead>
                         <tr>
-                          <th>Season</th>
-                          <th>Team</th>
-                          <th>GP</th>
-                          <th>GS</th>
-                          <th>MIN</th>
-                          <th>PTS</th>
-                          <th>REB</th>
-                          <th>AST</th>
-                          <th>STL</th>
-                          <th>BLK</th>
-                          <th>TOV</th>
-                          <th>FG%</th>
-                          <th>3P%</th>
-                          <th>FT%</th>
+                          <Th label="Season" sortKey="season" />
+                          <Th label="Team" sortKey="team" />
+                          <Th label="GP" sortKey="gamesPlayed" />
+                          <Th label="GS" sortKey="gamesStarted" />
+                          <Th label="MIN" sortKey="minutes" />
+                          <Th label="PTS" sortKey="points" />
+                          <Th label="REB" sortKey="rebounds" />
+                          <Th label="AST" sortKey="assists" />
+                          <Th label="STL" sortKey="steals" />
+                          <Th label="BLK" sortKey="blocks" />
+                          <Th label="TOV" sortKey="turnovers" />
+                          <Th label="FG%" sortKey="fgPct" className="players-pct-cell" />
+                          <Th label="3P%" sortKey="fg3Pct" className="players-pct-cell" />
+                          <Th label="FT%" sortKey="ftPct" className="players-pct-cell" />
                         </tr>
                       </thead>
                       <tbody>
-                        {[...careerStats.seasons]
-                          .sort((a, b) => b.season.localeCompare(a.season))
-                          .map((s, i) => (
+                        {sortedSeasons.map((s, i) => {
+                          // Highlight most recent season only when in chronological order
+                          const isNewest = !sort.key && i === 0;
+                          return (
                             <tr
                               key={`${s.season}-${s.team}-${i}`}
-                              className={i === 0 ? 'highlight-row' : ''}
+                              className={isNewest ? 'highlight-row' : ''}
                             >
                               <td className="season-col">{s.season}</td>
                               <td className="team-col">{s.team || '—'}</td>
@@ -468,7 +590,8 @@ export default function Players() {
                                 {fmtPct(s.ftPct)}
                               </td>
                             </tr>
-                          ))}
+                          );
+                        })}
                       </tbody>
                     </table>
                   </div>

--- a/frontend/src/pages/Players/Players.tsx
+++ b/frontend/src/pages/Players/Players.tsx
@@ -7,11 +7,11 @@ interface Player {
   playerId: number;
   fullName: string;
   teamId: number;
-  team: string;
+  team: string; // abbreviation e.g. "LAL"
   teamName: string;
   fromYear: string;
   toYear: string;
-  rosterStatus: number;
+  rosterStatus: number; // 1 = active
 }
 
 interface CareerSeason {
@@ -114,48 +114,21 @@ function useDebounce<T>(value: T, delay: number): T {
   return debounced;
 }
 
-// ─── Sort Icon ─────────────────────────────────────────────────────────────────
+// ─── Component ─────────────────────────────────────────────────────────────────
 
-function SortIcon({
-  direction,
-  active,
-  color,
-}: {
-  direction: SortDirection;
-  active: boolean;
-  color: string;
-}) {
+function SortIcon({ direction, active, color }: { direction: SortDirection; active: boolean; color: string }) {
   const dimColor = 'rgba(255,255,255,0.18)';
-  const upActive = active && direction === 'asc';
-  const downActive = active && direction === 'desc';
-
   return (
-    <span
-      className="sort-icon"
-      aria-hidden="true"
-      style={{ display: 'inline-flex', flexDirection: 'column', gap: '1px', marginLeft: '4px', verticalAlign: 'middle', lineHeight: 1 }}
-    >
-      {/* Up caret */}
+    <span style={{ display: 'inline-flex', flexDirection: 'column', gap: '1px', marginLeft: '4px', verticalAlign: 'middle' }}>
       <svg width="7" height="5" viewBox="0 0 7 5" fill="none">
-        <path
-          d="M3.5 0.5L6.5 4.5H0.5L3.5 0.5Z"
-          fill={upActive ? color : dimColor}
-          style={{ transition: 'fill 0.15s' }}
-        />
+        <path d="M3.5 0.5L6.5 4.5H0.5L3.5 0.5Z" fill={active && direction === 'asc' ? color : dimColor} style={{ transition: 'fill 0.15s' }} />
       </svg>
-      {/* Down caret */}
       <svg width="7" height="5" viewBox="0 0 7 5" fill="none">
-        <path
-          d="M3.5 4.5L0.5 0.5H6.5L3.5 4.5Z"
-          fill={downActive ? color : dimColor}
-          style={{ transition: 'fill 0.15s' }}
-        />
+        <path d="M3.5 4.5L0.5 0.5H6.5L3.5 4.5Z" fill={active && direction === 'desc' ? color : dimColor} style={{ transition: 'fill 0.15s' }} />
       </svg>
     </span>
   );
 }
-
-// ─── Component ─────────────────────────────────────────────────────────────────
 
 export default function Players() {
   // ── Sidebar state ──────────────────────────────────────────────────────────
@@ -170,14 +143,13 @@ export default function Players() {
   const [careerStats, setCareerStats] = useState<CareerStats | null>(null);
   const [loadingCareer, setLoadingCareer] = useState(false);
   const [errorCareer, setErrorCareer] = useState<string | null>(null);
-
-  // ── Sort state ─────────────────────────────────────────────────────────────
   const [sort, setSort] = useState<SortState>({ key: null, direction: null });
 
   const debouncedSearch = useDebounce(searchQuery, 300);
   const listRef = useRef<HTMLDivElement>(null);
 
   // ── 1. Fetch player list ───────────────────────────────────────────────────
+  // GET /api/players?search=&currentOnly=0|1
   useEffect(() => {
     const load = async () => {
       setLoadingPlayers(true);
@@ -202,13 +174,13 @@ export default function Players() {
   }, [debouncedSearch, activeOnly]);
 
   // ── 2. Fetch career stats when a player is selected ────────────────────────
+  // GET /api/players/:playerId/career
   useEffect(() => {
     if (!selectedPlayer) return;
     const load = async () => {
       setLoadingCareer(true);
       setErrorCareer(null);
       setCareerStats(null);
-      // Reset sort when switching players
       setSort({ key: null, direction: null });
       try {
         const res = await fetch(
@@ -227,43 +199,10 @@ export default function Players() {
     load();
   }, [selectedPlayer]);
 
-  // ── Sort handler: cycles null → desc → asc → null (chronological) ──────────
-  const handleSort = useCallback((key: SortKey) => {
-    setSort((prev) => {
-      if (prev.key !== key) {
-        // New column: start with desc
-        return { key, direction: 'desc' };
-      }
-      if (prev.direction === 'desc') return { key, direction: 'asc' };
-      // Was asc → reset to chronological
-      return { key: null, direction: null };
-    });
-  }, []);
-
-  // ── Sort the seasons ───────────────────────────────────────────────────────
-  const sortedSeasons = (() => {
-    if (!careerStats?.seasons) return [];
-    const base = [...careerStats.seasons].sort((a, b) =>
-      b.season.localeCompare(a.season),
-    );
-    if (!sort.key || !sort.direction) return base;
-
-    return [...base].sort((a, b) => {
-      const aVal = a[sort.key!] ?? 0;
-      const bVal = b[sort.key!] ?? 0;
-      if (typeof aVal === 'string' && typeof bVal === 'string') {
-        return sort.direction === 'asc'
-          ? aVal.localeCompare(bVal)
-          : bVal.localeCompare(aVal);
-      }
-      const diff = (aVal as number) - (bVal as number);
-      return sort.direction === 'asc' ? diff : -diff;
-    });
-  })();
-
   // ── Derived values ─────────────────────────────────────────────────────────
   const colors = selectedPlayer ? getColors(selectedPlayer.team) : null;
 
+  // Most recent season for the stat highlights in the header
   const latestSeason = careerStats?.seasons?.length
     ? [...careerStats.seasons].sort((a, b) =>
         b.season.localeCompare(a.season),
@@ -274,37 +213,27 @@ export default function Players() {
     setSelectedPlayer(player);
   }, []);
 
-  // ── Column header helper ───────────────────────────────────────────────────
-  const Th = ({
-    label,
-    sortKey,
-    className,
-  }: {
-    label: string;
-    sortKey: SortKey;
-    className?: string;
-  }) => {
-    const isActive = sort.key === sortKey;
-    const accentColor = colors?.secondary ?? '#ffffff';
+  const handleSort = useCallback((key: SortKey) => {
+    setSort((prev) => {
+      if (prev.key !== key) return { key, direction: 'desc' };
+      if (prev.direction === 'desc') return { key, direction: 'asc' };
+      return { key: null, direction: null }; // reset to chronological
+    });
+  }, []);
 
-    return (
-      <th
-        className={`sortable-th${isActive ? ' sort-active' : ''}${className ? ` ${className}` : ''}`}
-        onClick={() => handleSort(sortKey)}
-        style={isActive ? { color: accentColor } : undefined}
-        title={`Sort by ${label}`}
-      >
-        <span className="th-inner">
-          {label}
-          <SortIcon
-            direction={sort.direction}
-            active={isActive}
-            color={accentColor}
-          />
-        </span>
-      </th>
-    );
-  };
+const sortedSeasons = (() => {
+    if (!careerStats?.seasons) return [];
+    const base = [...careerStats.seasons].sort((a, b) => b.season.localeCompare(a.season));
+    if (!sort.key || !sort.direction) return base;
+    return [...base].sort((a, b) => {
+      const aVal = a[sort.key!] ?? 0;
+      const bVal = b[sort.key!] ?? 0;
+      if (typeof aVal === 'string' && typeof bVal === 'string')
+        return sort.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+      const diff = (aVal as number) - (bVal as number);
+      return sort.direction === 'asc' ? diff : -diff;
+    });
+  })();
 
   // ── Render ─────────────────────────────────────────────────────────────────
   return (
@@ -313,6 +242,7 @@ export default function Players() {
       <aside className="players-sidebar">
         <h2 className="players-sidebar-title">Players</h2>
 
+        {/* Search */}
         <div className="players-search-wrap">
           <span className="players-search-icon">⌕</span>
           <input
@@ -324,6 +254,7 @@ export default function Players() {
           />
         </div>
 
+        {/* Active-only toggle */}
         <div className="players-toggle-row">
           <input
             id="active-toggle"
@@ -337,15 +268,18 @@ export default function Players() {
           </label>
         </div>
 
+        {/* Status */}
         {loadingPlayers && <p className="players-loading">Loading…</p>}
         {errorPlayers && <p className="players-error">{errorPlayers}</p>}
 
+        {/* Count */}
         {!loadingPlayers && players.length > 0 && (
           <p className="players-count-badge">
             {players.length} player{players.length !== 1 ? 's' : ''}
           </p>
         )}
 
+        {/* List */}
         <div className="players-list" ref={listRef}>
           {players.map((player) => {
             const c = getColors(player.team);
@@ -392,6 +326,7 @@ export default function Players() {
       {/* ── Main Panel ── */}
       <main className="players-main">
         <div className="players-panel">
+          {/* Empty state */}
           {!selectedPlayer && (
             <p className="players-placeholder">
               Select a player to view their career stats.
@@ -468,6 +403,7 @@ export default function Players() {
                     )}
                   </div>
 
+                  {/* Latest season highlight stats */}
                   {loadingCareer && (
                     <p className="players-loading">Loading stats…</p>
                   )}
@@ -521,47 +457,55 @@ export default function Players() {
               {/* ── Career Stats Table ── */}
               {careerStats && careerStats.seasons.length > 0 && (
                 <>
-                  <div className="players-career-title-row">
-                    <p className="players-career-title">Career Stats</p>
-                    {sort.key && (
-                      <button
-                        className="sort-reset-btn"
-                        onClick={() => setSort({ key: null, direction: null })}
-                        title="Reset to chronological order"
-                      >
-                        Reset order
-                      </button>
-                    )}
-                  </div>
+                  <p className="players-career-title">Career Stats</p>
                   <div className="players-career-table-wrap">
                     <table className="players-career-table">
                       <thead>
                         <tr>
-                          <Th label="Season" sortKey="season" />
-                          <Th label="Team" sortKey="team" />
-                          <Th label="GP" sortKey="gamesPlayed" />
-                          <Th label="GS" sortKey="gamesStarted" />
-                          <Th label="MIN" sortKey="minutes" />
-                          <Th label="PTS" sortKey="points" />
-                          <Th label="REB" sortKey="rebounds" />
-                          <Th label="AST" sortKey="assists" />
-                          <Th label="STL" sortKey="steals" />
-                          <Th label="BLK" sortKey="blocks" />
-                          <Th label="TOV" sortKey="turnovers" />
-                          <Th label="FG%" sortKey="fgPct" className="players-pct-cell" />
-                          <Th label="3P%" sortKey="fg3Pct" className="players-pct-cell" />
-                          <Th label="FT%" sortKey="ftPct" className="players-pct-cell" />
+                          {(
+                            [
+                              ['Season', 'season'],
+                              ['Team', 'team'],
+                              ['GP', 'gamesPlayed'],
+                              ['GS', 'gamesStarted'],
+                              ['MIN', 'minutes'],
+                              ['PTS', 'points'],
+                              ['REB', 'rebounds'],
+                              ['AST', 'assists'],
+                              ['STL', 'steals'],
+                              ['BLK', 'blocks'],
+                              ['TOV', 'turnovers'],
+                              ['FG%', 'fgPct'],
+                              ['3P%', 'fg3Pct'],
+                              ['FT%', 'ftPct'],
+                            ] as [string, SortKey][]
+                          ).map(([label, key]) => {
+                            const isActive = sort.key === key;
+                            return (
+                              <th
+                                key={key}
+                                onClick={() => handleSort(key)}
+                                style={{
+                                  cursor: 'pointer',
+                                  userSelect: 'none',
+                                  whiteSpace: 'nowrap',
+                                  color: isActive ? colors.secondary : undefined,
+                                  transition: 'color 0.15s',
+                                }}
+                              >
+                                {label}
+                                <SortIcon direction={sort.direction} active={isActive} color={colors.secondary} />
+                              </th>
+                            );
+                          })}
                         </tr>
                       </thead>
                       <tbody>
-                        {sortedSeasons.map((s, i) => {
-                          // Highlight most recent season only when in chronological order
-                          const isNewest = !sort.key && i === 0;
-                          return (
-                            <tr
-                              key={`${s.season}-${s.team}-${i}`}
-                              className={isNewest ? 'highlight-row' : ''}
-                            >
+                        {sortedSeasons.map((s, i) => (
+                          <tr
+                            key={`${s.season}-${s.team}-${i}`}
+                            className={!sort.key && i === 0 ? 'highlight-row' : ''}
+                          >
                               <td className="season-col">{s.season}</td>
                               <td className="team-col">{s.team || '—'}</td>
                               <td>{fmtStat(s.gamesPlayed)}</td>
@@ -590,8 +534,7 @@ export default function Players() {
                                 {fmtPct(s.ftPct)}
                               </td>
                             </tr>
-                          );
-                        })}
+                          ))}
                       </tbody>
                     </table>
                   </div>


### PR DESCRIPTION
Added sorting functionality to players page to allow users to filter players career stats by asc, desc, or just chronological order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Career stats table columns are now sortable—click column headers to cycle through ascending, descending, and default ordering
  * Visual sort direction indicators appear on active column headers for easy reference
  * Reset button available to return to the original unsorted view

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheBallerz/BallerzStatApp/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->