### PR TITLE
Implemented: rosters on team panels + player routes from roster to players page 

### DIFF
--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -136,10 +136,17 @@ router.get('/players/top', async (req, res) => {
 router.get('/players', async (req, res) => {
   try {
     const search = normalizeText(req.query.search || '');
+    const { teamId, includeStats } = req.query;
 
     // Build a filter: if a search term is provided, match it case-insensitively
     // against either part of the player's name. No search = return everyone.
     const filter = {};
+
+    // if teamId is queried then filter by teamId
+    if (teamId) {
+      filter.teamId = teamId;
+    }
+
     if (search) {
       const regex = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
       filter.$or = [{ firstName: regex }, { lastName: regex }];
@@ -151,10 +158,20 @@ router.get('/players', async (req, res) => {
 
     const result = players.map((p) => ({
       playerId:     p.nbaId,
+      nbaId: p.nbaId,
+      mongoId: p._id,
       fullName:     `${p.firstName} ${p.lastName}`,
+      firstName: p.firstName,
+      lastName: p.lastName,
+      position: p.position,
+      jerseyNumber: p.jerseyNumber,
+      imageUrl: p.imageUrl,
+
+      teamMongoId: p.teamId?._id,
       teamId:       p.teamId?.nbaId        ?? 0,
       team:         p.teamId?.abbreviation ?? '',
       teamName:     p.teamId?.name         ?? '',
+      
       // fromYear / toYear / rosterStatus are not stored in the Player model.
       // The frontend renders fromYear–toYear as "–" when both are empty, and
       // always shows the Active badge since rosterStatus is always 1 here.
@@ -163,7 +180,38 @@ router.get('/players', async (req, res) => {
       rosterStatus: 1,
     }));
 
-    res.json(result);
+    if (includeStats !== '1') {
+      return res.json(result);
+    }
+    
+    const nbaPlayerIds = result.map((player) => player.playerId);
+    
+    const stats = await PlayerSeasonStats.find({
+      nbaPlayerId: { $in: nbaPlayerIds },
+    }).lean();
+    
+    const statsByNbaPlayerId = new Map(
+      stats.map((stat) => [stat.nbaPlayerId, stat]),
+    );
+    
+    const resultWithStats = result.map((player) => {
+      const stat = statsByNbaPlayerId.get(player.playerId);
+    
+      return {
+        ...player,
+        seasonStats: {
+          ppg: stat?.avgPoints ?? 0,
+          rpg: stat?.avgRebounds ?? 0,
+          apg: stat?.avgAssists ?? 0,
+          spg: stat?.avgSteals ?? 0,
+          bpg: stat?.avgBlocks ?? 0,
+          fgPct: stat?.fgPct ?? 0,
+          threePct: stat?.fg3Pct ?? 0,
+        },
+      };
+    });
+    
+    res.json(resultWithStats);
   } catch (error) {
     console.error('Error fetching players:', error.message);
     res.status(500).json({ error: 'Failed to fetch players', details: error.message });

--- a/backend/src/routes/players.js
+++ b/backend/src/routes/players.js
@@ -137,6 +137,7 @@ router.get('/players', async (req, res) => {
   try {
     const search = normalizeText(req.query.search || '');
     const { teamId, includeStats } = req.query;
+    const mongoose = require('mongoose');
 
     // Build a filter: if a search term is provided, match it case-insensitively
     // against either part of the player's name. No search = return everyone.
@@ -144,6 +145,9 @@ router.get('/players', async (req, res) => {
 
     // if teamId is queried then filter by teamId
     if (teamId) {
+      if (!mongoose.Types.ObjectId.isValid(teamId)) {
+        return res.status(400).json({ error: 'teamId must be a valid Mongo ObjectId' });
+      }
       filter.teamId = teamId;
     }
 

--- a/frontend/src/components/players/PlayerDetailPanel.tsx
+++ b/frontend/src/components/players/PlayerDetailPanel.tsx
@@ -107,7 +107,9 @@ export default function PlayerDetailPanel({
         {loading ? (
           <p className="pdp-status">Loading…</p>
         ) : error || !stats ? (
-          <p className="pdp-status">{error || 'No stats available for this season'}</p>
+          <p className="pdp-status">
+            {error || 'No stats available for this season'}
+          </p>
         ) : (
           <>
             <p className="pdp-section-label">Season Averages</p>

--- a/frontend/src/components/teams/TeamDetailPanel.tsx
+++ b/frontend/src/components/teams/TeamDetailPanel.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import { TEAM_LOGOS } from '../../assets/teamLogos';
-import { fetchTeam } from '../../services/nbaApi';
+import { fetchTeam, fetchPlayers } from '../../services/nbaApi';
+import { useNavigate } from 'react-router-dom';
 import './teamDetailPanel.css';
 
 type SelectedTeam = {
+  mongoId: string;
   name: string;
   division: string;
   teamId: number;
@@ -12,6 +14,7 @@ type SelectedTeam = {
 };
 
 type TeamDetail = {
+  mongoId: string;
   teamId: number;
   city: string;
   name: string;
@@ -27,6 +30,27 @@ type TeamDetail = {
   fgPct: number;
 };
 
+type TeamPlayer = {
+  mongoId: string;
+  nbaId: number;
+  fullName: string;
+  firstName: string;
+  lastName: string;
+  position: string;
+  jerseyNumber: number;
+  imageUrl: string;
+  team: string;
+  seasonStats?: {
+    ppg: number;
+    rpg: number;
+    apg: number;
+    spg: number;
+    bpg: number;
+    fgPct: number;
+    threePct: number;
+  };
+};
+
 type Props = {
   team: SelectedTeam;
   onClose: () => void;
@@ -35,8 +59,10 @@ type Props = {
 export default function TeamDetailPanel({ team, onClose }: Props) {
   const logoSrc = TEAM_LOGOS?.[team.name];
   const [teamDetail, setTeamDetail] = useState<TeamDetail | null>(null);
+  const [roster, setRoster] = useState<TeamPlayer[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function loadTeamDetail() {
@@ -44,8 +70,13 @@ export default function TeamDetailPanel({ team, onClose }: Props) {
         setLoading(true);
         setError('');
 
-        const data = await fetchTeam(team.teamId);
-        setTeamDetail(data);
+        const [teamData, rosterData] = await Promise.all([
+          fetchTeam(team.teamId),
+          fetchPlayers(team.mongoId),
+        ]);
+
+        setTeamDetail(teamData);
+        setRoster(rosterData);
       } catch (err) {
         console.error(err);
         setError('Failed to load team data.');
@@ -55,7 +86,7 @@ export default function TeamDetailPanel({ team, onClose }: Props) {
     }
 
     loadTeamDetail();
-  }, [team.teamId]);
+  }, [team.teamId, team.mongoId]);
 
   return (
     <div
@@ -135,6 +166,69 @@ export default function TeamDetailPanel({ team, onClose }: Props) {
               <span className="team-stat-value">
                 {(teamDetail.fgPct * 100).toFixed(1)}%
               </span>
+            </div>
+
+            <div className="team-roster-section">
+              <h3 className="team-roster-title">Roster</h3>
+
+              <div className="team-roster-list">
+                {roster.map((player) => (
+                  <button
+                    key={player.mongoId}
+                    className="team-roster-player"
+                    onClick={() =>
+                      navigate('/players', {
+                        state: {
+                          openPlayer: true,
+                          nbaPlayerId: player.nbaId,
+                          playerName: player.fullName,
+                          teamAbbr: player.team,
+                        },
+                      })
+                    }
+                  >
+                    <img
+                      src={player.imageUrl}
+                      alt={player.fullName}
+                      className="team-roster-headshot"
+                    />
+                    <span className="team-roster-number">
+                      #{player.jerseyNumber}  {player.position}
+                    </span>
+
+                    <span className="team-roster-name">{player.fullName}</span>
+
+                    <span className="team-roster-stat">
+                      {player.seasonStats?.ppg?.toFixed(1) ?? '0.0'} PPG
+                    </span>
+
+                    <span className="team-roster-stat">
+                      {player.seasonStats?.rpg?.toFixed(1) ?? '0.0'} RPG
+                    </span>
+
+                    <span className="team-roster-stat">
+                      {player.seasonStats?.apg?.toFixed(1) ?? '0.0'} APG
+                    </span>
+
+                    <span className="team-roster-stat">
+                      {player.seasonStats?.spg?.toFixed(1) ?? '0.0'} SPG
+                    </span>
+
+                    <span className="team-roster-stat">
+                      {player.seasonStats?.bpg?.toFixed(1) ?? '0.0'} BPG
+                    </span>
+
+                    <span className="team-roster-stat">
+                      {((player.seasonStats?.fgPct ?? 0) * 100).toFixed(1)} FG%
+                    </span>
+
+                    <span className="team-roster-stat">
+                      {((player.seasonStats?.threePct ?? 0) * 100).toFixed(1)}{' '}
+                      3P%
+                    </span>
+                  </button>
+                ))}
+              </div>
             </div>
           </>
         )}

--- a/frontend/src/components/teams/teamDetailPanel.css
+++ b/frontend/src/components/teams/teamDetailPanel.css
@@ -152,3 +152,89 @@
   font-weight: 700;
   color: #ffffff; /* full white */
 }
+
+.team-roster-section {
+  margin-top: 20px;
+}
+
+.team-roster-title {
+  color: white;
+  margin-bottom: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.team-roster-list {
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  padding-right: 6px;
+}
+
+.team-roster-player {
+  width: 100%;
+
+  display: grid;
+  grid-template-columns:
+    40px /* headshot */
+    56px /* jersey */
+    1fr /* name */
+    56px /* ppg */
+    56px /* rpg */
+    56px /* apg */
+    56px /* spg */
+    56px /* bpg */
+    64px /* fg% */
+    64px /* 3p% */
+    40px; /* position */
+  align-items: center;
+  gap: 10px;
+
+  padding: 10px 12px;
+
+  border: none;
+  border-radius: 10px;
+
+  background: rgba(255, 255, 255, 0.06);
+  color: white;
+
+  cursor: pointer;
+  text-align: left;
+
+  transition: background 0.2s ease;
+}
+
+.team-roster-stat {
+  font-size: 0.72rem;
+  opacity: 0.78;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.team-roster-player:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.team-roster-headshot {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.team-roster-number,
+.team-roster-position {
+  opacity: 0.7;
+  font-size: 0.9rem;
+}
+
+.team-roster-name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/pages/Players/Players.tsx
+++ b/frontend/src/pages/Players/Players.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
 import './Players.css';
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
@@ -121,12 +122,30 @@ export default function Players() {
   const [careerStats, setCareerStats] = useState<CareerStats | null>(null);
   const [loadingCareer, setLoadingCareer] = useState(false);
   const [errorCareer, setErrorCareer] = useState<string | null>(null);
+  const location = useLocation();
 
   const debouncedSearch = useDebounce(searchQuery, 300);
   const listRef = useRef<HTMLDivElement>(null);
 
   // ── 1. Fetch player list ───────────────────────────────────────────────────
   // GET /api/players?search=&currentOnly=0|1
+  useEffect(() => {
+    const state = location.state;
+
+    if (!state?.openPlayer) return;
+
+    setSelectedPlayer({
+      playerId: state.nbaPlayerId,
+      fullName: state.playerName,
+      teamId: 0,
+      team: state.teamAbbr,
+      teamName: '',
+      fromYear: '',
+      toYear: '',
+      rosterStatus: 1,
+    });
+  }, [location.state]);
+
   useEffect(() => {
     const load = async () => {
       setLoadingPlayers(true);

--- a/frontend/src/pages/Teams/TeamsPage.tsx
+++ b/frontend/src/pages/Teams/TeamsPage.tsx
@@ -5,6 +5,7 @@ import { fetchTeams } from '../../services/nbaApi';
 import './TeamsPage.css';
 
 type SelectedTeam = {
+  mongoId: string;
   name: string;
   division: string;
   teamId: number;
@@ -14,6 +15,7 @@ type SelectedTeam = {
 };
 
 type Team = {
+  mongoId: string;
   teamId: number;
   teamName: string;
   teamAbbreviation: string;
@@ -49,6 +51,7 @@ function groupTeamsByDivision(teams: Team[]): Division[] {
     teams: teams
       .filter((team) => abbreviations.includes(team.teamAbbreviation))
       .map((team) => ({
+        mongoId: team.mongoId,
         name: team.teamName,
         division: divisionName,
         teamId: team.teamId,
@@ -76,6 +79,7 @@ export default function TeamsPage() {
         console.log('RAW TEAMS API:', data);
 
         const mappedTeams: Team[] = data.map((team: Team) => ({
+          mongoId: team.mongoId,
           teamId: team.teamId,
           teamName: team.teamName,
           teamAbbreviation: team.teamAbbreviation,

--- a/frontend/src/services/nbaApi.ts
+++ b/frontend/src/services/nbaApi.ts
@@ -19,3 +19,19 @@ export async function fetchTeam(teamId: number | string) {
 
   return res.json();
 }
+
+export async function fetchPlayers(teamMongoId: string) {
+  if (!teamMongoId) {
+    throw new Error('fetchPlayers requires a teamMongoId');
+  }
+
+  const res = await fetch(
+    `${API_BASE}/players?teamId=${teamMongoId}&includeStats=1`,
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch players: ${res.status}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
Implemented dynamic NBA team roster support using MongoDB-backed player data. Added roster fetching to the Team Detail Panel, including player headshots, positions, jersey numbers, and current season stats (PPG, RPG, APG, SPG, BPG, FG%, 3P%). Updated the shared /api/players route to optionally include season stats via query parameters while preserving existing functionality across the app. Added roster UI styling, scrollable player lists, and player-to-profile routing from the Teams page to the Players page using React Router state. Fixed frontend/backend data flow issues involving Mongo team IDs, route state navigation, and stat hydration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team detail panels now show full rosters with player headshots, jersey/position, and expanded season stats (PPG, RPG, APG, SPG, BPG, FG%, 3P%).
  * Roster entries are clickable and navigate directly to a player’s detail view.
  * Players page can auto-open a player when navigated from a roster, preserving player and team context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheBallerz/BallerzStatApp/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->